### PR TITLE
Fix bug with profile view variables

### DIFF
--- a/main/views.py
+++ b/main/views.py
@@ -92,6 +92,9 @@ def userProfile(request, username):
 
     bookmarked = []
 
+    # Initialise queryset to avoid UnboundLocalError when user is not authenticated
+    bookmarkedArticles = Bookmark.objects.none()
+
     if request.user.is_authenticated:
         bookmarkedArticles = Bookmark.objects.filter(user=user)
         for bookmark in bookmarkedArticles:


### PR DESCRIPTION
## Summary
- prevent unbound variable in `userProfile` view

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f44c5225c83248110498072dd5b63